### PR TITLE
Restore `run_callbacks` call in `CDiscord::Update`

### DIFF
--- a/src/engine/client/discord.cpp
+++ b/src/engine/client/discord.cpp
@@ -113,6 +113,8 @@ public:
 
 				m_pActivityManager->update_activity(m_pActivityManager, &m_Activity, nullptr, nullptr);
 			}
+
+			m_pCore->run_callbacks(m_pCore);
 		}
 	}
 


### PR DESCRIPTION
I assume this was removed by mistake in a merge commit as I remember getting weird conflicts in discord.cpp too, but if this was intentional feel free to close