### PR TITLE
Fix out of bounds access from uninitialized m_ActiveWeapon in the prediction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3427,6 +3427,7 @@ if((GTEST_FOUND OR DOWNLOAD_GTEST) AND SERVER)
     dbg_test.cpp
     editor_test.cpp
     fs_test.cpp
+    gamecore_test.cpp
     gameworld_test.cpp
     git_revision_test.cpp
     hash_test.cpp

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -834,7 +834,7 @@ void CHud::RenderCursor()
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && GameClient()->m_Snap.m_pLocalCharacter)
 	{
 		// Render local cursor
-		CurWeapon = maximum(0, GameClient()->m_aClients[GameClient()->m_Snap.m_LocalClientId].m_Predicted.m_ActiveWeapon);
+		CurWeapon = maximum(0, GameClient()->m_aClients[GameClient()->m_Snap.m_LocalClientId].m_Predicted.m_ActiveWeapon % NUM_WEAPONS);
 		TargetPos = GameClient()->m_Controls.m_aTargetPos[g_Config.m_ClDummy];
 	}
 	else

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -53,7 +53,7 @@ void CCharacter::HandleJetpack()
 	if(m_NumInputs < 2)
 		return;
 
-	if(m_Core.m_ActiveWeapon < 0)
+	if(!HasValidActiveWeapon())
 		return;
 
 	vec2 Direction = normalize(vec2(m_LatestInput.m_TargetX, m_LatestInput.m_TargetY));
@@ -283,7 +283,7 @@ void CCharacter::FireWeapon()
 	if(CountInput(m_LatestPrevInput.m_Fire, m_LatestInput.m_Fire).m_Presses)
 		WillFire = true;
 
-	if(FullAuto && (m_LatestInput.m_Fire & 1) && m_Core.m_ActiveWeapon >= 0 && m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo)
+	if(FullAuto && (m_LatestInput.m_Fire & 1) && HasValidActiveWeapon() && m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo)
 		WillFire = true;
 
 	if(!WillFire)
@@ -301,7 +301,7 @@ void CCharacter::FireWeapon()
 	}
 
 	// check for ammo
-	if(m_Core.m_ActiveWeapon < 0 || !m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo || m_FreezeTime)
+	if(!HasValidActiveWeapon() || !m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo || m_FreezeTime)
 	{
 		return;
 	}
@@ -491,7 +491,7 @@ void CCharacter::FireWeapon()
 	m_AttackTick = GameWorld()->GameTick(); // NOLINT(clang-analyzer-unix.Malloc)
 
 	// -1 is no weapon, handled here so pain sound still plays when firing in freeze
-	if(!m_ReloadTimer && m_Core.m_ActiveWeapon != -1)
+	if(!m_ReloadTimer && HasValidActiveWeapon())
 	{
 		m_ReloadTimer = GetTuning(GetOverriddenTuneZone())->GetWeaponFireDelay(m_Core.m_ActiveWeapon) * GameWorld()->GameTickSpeed();
 	}
@@ -1210,7 +1210,7 @@ bool CCharacter::Unfreeze()
 {
 	if(m_FreezeTime > 0)
 	{
-		if(m_Core.m_ActiveWeapon >= 0 && !m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Got)
+		if(HasValidActiveWeapon() && !m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Got)
 			m_Core.m_ActiveWeapon = WEAPON_GUN;
 		m_FreezeTime = 0;
 		m_Core.m_FreezeStart = 0;
@@ -1410,7 +1410,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 		// ddnetcharacter is not available, try to get some info from the tunings and the character netobject instead.
 
 		// remove weapons that are unavailable. if the current weapon is ninja just set ammo to zero in case the player is frozen
-		if(m_Core.m_ActiveWeapon >= 0 && pChar->m_Weapon != m_Core.m_ActiveWeapon)
+		if(HasValidActiveWeapon() && pChar->m_Weapon != m_Core.m_ActiveWeapon)
 		{
 			if(pChar->m_Weapon == WEAPON_NINJA)
 			{
@@ -1535,7 +1535,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 
 	// in most cases the reload timer can be determined from the last attack tick
 	// (this is only needed for autofire weapons to prevent the predicted reload timer from desyncing)
-	if(IsLocal && m_Core.m_ActiveWeapon != -1 && m_Core.m_ActiveWeapon != WEAPON_HAMMER && !m_Core.m_aWeapons[WEAPON_NINJA].m_Got)
+	if(IsLocal && HasValidActiveWeapon() && m_Core.m_ActiveWeapon != WEAPON_HAMMER && !m_Core.m_aWeapons[WEAPON_NINJA].m_Got)
 	{
 		if(maximum(m_LastTuneZoneTick, m_LastWeaponSwitchTick) + GameWorld()->GameTickSpeed() < GameWorld()->GameTick())
 		{

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -88,6 +88,9 @@ public:
 	int GetLastWeapon() const { return m_LastWeapon; }
 	void SetLastWeapon(int LastWeap) { m_LastWeapon = LastWeap; }
 	int GetActiveWeapon() const { return m_Core.m_ActiveWeapon; }
+	// m_ActiveWeapon is -1 when no weapon is active, everything else has to be a
+	// valid index into m_aWeapons before it may be used as one
+	bool HasValidActiveWeapon() const { return m_Core.m_ActiveWeapon >= 0 && m_Core.m_ActiveWeapon < NUM_WEAPONS; }
 	void SetActiveWeapon(int ActiveWeapon);
 	CCharacterCore GetCore() { return m_Core; }
 	void SetCore(const CCharacterCore &Core) { m_Core = Core; }

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -160,6 +160,12 @@ void CCharacterCore::Reset()
 	m_Jumps = 2;
 	m_TriggeredEvents = 0;
 
+	// m_ActiveWeapon is used to index m_aWeapons, leaving it uninitialized causes
+	// out of bounds accesses in the client prediction (CCharacter::Unfreeze() etc.)
+	m_ActiveWeapon = WEAPON_GUN;
+	for(CWeaponStat &Weapon : m_aWeapons)
+		Weapon = CWeaponStat{};
+
 	// DDNet Character
 	m_Solo = false;
 	m_Jetpack = false;

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -241,7 +241,8 @@ public:
 	void Quantize();
 
 	// DDRace
-	int m_Id;
+	// -1 means no player, assigned by the owner after Reset()
+	int m_Id = -1;
 	bool m_Reset;
 	CCollision *Collision() { return m_pCollision; }
 
@@ -276,7 +277,9 @@ public:
 private:
 	CTeamsCore *m_pTeams;
 	int m_MoveRestrictions;
-	int m_HookedPlayer;
+	// Reset() passes this to SetHookedPlayer(), which reads it and m_Id before
+	// either has been assigned, so both need a defined value from the start
+	int m_HookedPlayer = -1;
 	static bool IsSwitchActiveCb(unsigned char Number, void *pUser);
 };
 

--- a/src/test/gamecore_test.cpp
+++ b/src/test/gamecore_test.cpp
@@ -1,0 +1,30 @@
+#include <game/gamecore.h>
+
+#include <gtest/gtest.h>
+
+// Reset() has to leave the core in a fully initialized state. Both the server and
+// the client prediction index m_aWeapons with m_ActiveWeapon (CCharacter::Unfreeze(),
+// CCharacter::FireWeapon(), ...), so an uninitialized m_ActiveWeapon is an out of
+// bounds access waiting to happen.
+TEST(GameCore, ResetInitializesWeapons)
+{
+	CCharacterCore Core;
+	// values as found in uninitialized memory
+	Core.m_ActiveWeapon = 0x5105503e;
+	for(auto &Weapon : Core.m_aWeapons)
+	{
+		Weapon.m_AmmoRegenStart = 0x5105503e;
+		Weapon.m_Ammo = 0x5105503e;
+		Weapon.m_Ammocost = 0x5105503e;
+		Weapon.m_Got = true;
+	}
+
+	Core.Reset();
+
+	EXPECT_GE(Core.m_ActiveWeapon, 0);
+	EXPECT_LT(Core.m_ActiveWeapon, NUM_WEAPONS);
+	for(const auto &Weapon : Core.m_aWeapons)
+	{
+		EXPECT_FALSE(Weapon.m_Got);
+	}
+}


### PR DESCRIPTION
## Problem

The client segfaults in `CCharacter::Unfreeze()` (prediction). Reproducible on a tee whose snapshotted weapon is `WEAPON_NINJA`:

```
mov    0x408(%rdi),%eax          ; m_Core.m_ActiveWeapon = 0x5105503e (heap garbage)
test   %eax,%eax
js     ...                       ; only the >= 0 guard, no upper bound
shl    $0x4,%rax                 ; * sizeof(CWeaponStat)
cmpb   $0x0,0x418(%rdi,%rax,1)   ; m_aWeapons[i].m_Got -> reads ~20 GB past the object
```

`CCharacterCore::Reset()` never initializes `m_ActiveWeapon` or `m_aWeapons`, so a freshly constructed prediction character keeps whatever was in the heap until `CCharacter::Read()` assigns a weapon. `Read()` only assigns it when the snapshotted weapon is not `WEAPON_NINJA` — and the server snaps `WEAPON_NINJA` **without** `CHARACTERFLAG_WEAPON_NINJA` for ninjajetpack tees (`m_ActiveWeapon` is still `WEAPON_GUN`, so the flag is not set) and for frozen tees on old clients. Such a character never gets a valid `m_ActiveWeapon`, and the next `Unfreeze()` indexes `m_aWeapons` out of bounds.

Note that address watchpoints cannot catch this: nothing *writes* the garbage, and `CGameWorld::CopyWorld` re-`new`s the prediction characters every tick.

## A second uninitialized read, found with valgrind

While verifying this upstream I ran memcheck on this tree as well. `Reset()` also reads `m_HookedPlayer` and `m_Id` before anything assigns them — `SetHookedPlayer(-1)` at `gamecore.cpp:156` compares against both at `:703` and `:705`, and the owner assigns them *after* `Reset()`:

```
$ valgrind --tool=memcheck --track-origins=yes ./testrunner --gtest_filter='UninitProbe.*'

==147760== Conditional jump or move depends on uninitialised value(s)
==147760==    at CCharacterCore::SetHookedPlayer(int) (gamecore.cpp:703)
==147760==    by CCharacterCore::Reset() (gamecore.cpp:156)
==147760==  Uninitialised value was created by a heap allocation
...
==147760== ERROR SUMMARY: 4 errors from 4 contexts
```

Three of those are `m_HookedPlayer` / `m_Id`, the fourth is the `m_ActiveWeapon` read above. Nothing worse happens today only because `m_pWorld` is still null at that point and short circuits the branch that would evaluate `m_pWorld->m_apCharacters[m_HookedPlayer]`. After this PR the same probe reports `ERROR SUMMARY: 0 errors from 0 contexts`.

## Changes

1. **`Fix uninitialized m_ActiveWeapon crashing the prediction`** — `Reset()` sets `m_ActiveWeapon = WEAPON_GUN` and clears `m_aWeapons`, the way the server already does by hand in `CCharacter::Spawn()`.
2. **`Bound-check m_ActiveWeapon before using it as an index`** — the guards only checked `>= 0`. Adds `CCharacter::HasValidActiveWeapon()` and uses it everywhere `m_ActiveWeapon` indexes `m_aWeapons`, which also closes an out of bounds *write* in `Read()` and avoids `CTuningParams::GetWeaponFireDelay()`'s `dbg_assert_failed("invalid weapon")`. `-1` still means "no weapon". `CHud::RenderCursor()` gets the same `% NUM_WEAPONS` clamp the other cursor sites in that file already use.
3. **`Give m_Id and m_HookedPlayer a defined initial value`** — default member initializers, fixing the reads above. Initializing in the declaration rather than inside `Reset()` keeps `Reset()`'s detach logic intact for cores that really were hooked to someone.

## Upstream status

Worth knowing before you next merge DDNet:

* The prediction-constructor half of this is already fixed upstream by ddnet/ddnet#12547, merged about a week ago. It assigns `m_Core.m_ActiveWeapon = -1` in the prediction `CCharacter` constructor plus an `else if(m_Core.m_ActiveWeapon < 0)` fallback in `Read()`. This tree predates that PR, which is why the crash reproduces here and not on current DDNet master.
* Changes 1 and 3 are proposed upstream as ddnet/ddnet#12653. Change 2 is in that PR too, offered as optional hardening.

So a future DDNet merge will bring #12547 in on its own, and #12653 as well if it lands. Since these commits touch the same lines as the upstream ones, the merge should converge rather than conflict. If you would rather not carry a fork-local patch at all, the minimal alternative is cherry-picking ddnet/ddnet#12547 — that stops the crash, but leaves `Reset()` handing out undefined `m_ActiveWeapon` and the `m_HookedPlayer` read in place.

## Tests

New `src/test/gamecore_test.cpp` fills a core with garbage, calls `Reset()`, and asserts `m_ActiveWeapon` is a valid index and no weapon is marked as got. It fails without change 1 and passes with it. Full suite 339/339. Running in daily play since 2026-08-15.

The memcheck probe is a throwaway, not part of this PR; happy to attach it.

AI was used to draft the patch and this description. I reviewed all of it and verified the change independently — the unit test fails without the fix and passes with it, memcheck goes from 4 errors to 0, and the full suite passes.
