### PR TITLE
delete 20.0 texture fallback

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -330,8 +330,10 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadSpriteTexture(const CImageInfo
 	// check for invisible texture, maybe due to outdated game assets
 	if(FallbackImageInfo.has_value() && IsImageSubFullyTransparent(FromImageInfo, x, y, w, h))
 	{
-		log_warn("graphics", "Asset '%s' appears to be invisible, falling back to default", pSprite->m_pName);
-		return LoadSpriteTexture(FallbackImageInfo.value(), std::nullopt, pSprite);
+		// TClient: Do not fall back to default: players intentionally use transparent custom assets (e.g. hooks/cursors).
+		log_warn("graphics", "Asset '%s' appears to be invisible", pSprite->m_pName);
+		// log_warn("graphics", "Asset '%s' appears to be invisible, falling back to default", pSprite->m_pName);
+		// return LoadSpriteTexture(FallbackImageInfo.value(), std::nullopt, pSprite);
 	}
 
 	CImageInfo SpriteInfo;


### PR DESCRIPTION
Deletes the backup version of the invisible sprite that was added in version 20.0 (756dcc04f90e9d40ab29b4e4d848ec03ce621e1b - detects invisible objects when loading the sprite texture and replaces them with the default sprite).
This function treated fully transparent sprite areas in user resources as
broken/outdated and automatically replaced them with default sprites.
I think this only gets in the way: many players intentionally use transparent hooks, cursors, and similar user resources.
People have also complained about this behavior from my client.
  ## Checklist
  - [x] Tested the change ingame
  - [ ] Provided screenshots if it is a visual change
  - [ ] Tested in combination with possibly related configuration options
  - [ ] Written a unit test (especially base/) or added coverage to integration test
  - [x] Considered possible null pointers and out of bounds array indexing
  - [x] Changed no physics that affect existing maps
  - [ ] Tested the change with [ASan+UBSan or valgrind's 
  memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavio
  ursanitizer-or-valgrinds-memcheck) (optional)
  - [ ] I didn't use generative AI to generate more than single-line completions
  ---